### PR TITLE
[fix] 인피니티 스크롤 page 이슈 수정 #73

### DIFF
--- a/src/components/Common/ApartSearch/ApartSearchResultItem.tsx
+++ b/src/components/Common/ApartSearch/ApartSearchResultItem.tsx
@@ -94,7 +94,6 @@ export default function ApartSearchResultItem({
     setIsSlide(true);
     setIsDetailInfo(null);
     setMainInfo("SELECT");
-    console.log(data.data);
     if (apartSeparate === "apt") setApartInfo(data.data);
     else setWeakApartInfo(data.data);
   };

--- a/src/hooks/Search/useInfinityScroll.ts
+++ b/src/hooks/Search/useInfinityScroll.ts
@@ -22,8 +22,8 @@ export function useInfiniteScroll() {
   const setMarkerData = useMarkerStore((state) => state.setMarkerData);
   const map = useMarkerStore((state) => state.map);
 
-  const changeLocation = (results: any) => {
-    if (!location && page === 1) setLocation(true);
+  const changeLocation = (pageNum: number, results: any) => {
+    if (!location && pageNum === 1) setLocation(true);
     else return;
     if (map) {
       const newLocation = new naver.maps.LatLng(
@@ -43,7 +43,7 @@ export function useInfiniteScroll() {
       setPage(1);
       setHasMore(true);
       setTotalCount(0);
-      fetchData(page, keyword);
+      fetchData(1, keyword);
       setPrevKeyword(keyword);
     }
   }, [keyword]);
@@ -69,7 +69,7 @@ export function useInfiniteScroll() {
         {
           params: {
             keyword: searchKeyword,
-            page: page,
+            page: pageNum,
             num: 10,
           },
         }
@@ -82,7 +82,7 @@ export function useInfiniteScroll() {
       }
 
       const { results, totalElements } = response.data.data;
-      changeLocation(results);
+      changeLocation(pageNum, results);
       setTotalCount(totalElements);
       setItems((prevItems) => {
         const newItems = pageNum === 1 ? results : [...prevItems, ...results];


### PR DESCRIPTION
## 📌 이슈 번호

> #73

## 💬 리뷰 포인트

> 인피니티 스크롤 page state정의 이슈 수정

## 🚀 상세 설명

> 검색어 키워드 변경 시 page state 재정의 하도록 수정하였습니다.
> 로케이션 함수에 page값도 인자로 받도록 수정하였습니다.

## 📸 스크린샷

## 📢 노트
