### PR TITLE
[fix] 마커 선택 지도 이동 및 동일 검색 마커 이벤트 핸들러 동작 수정 #73

### DIFF
--- a/src/components/Common/ApartSearch/ApartSearchInput.tsx
+++ b/src/components/Common/ApartSearch/ApartSearchInput.tsx
@@ -26,6 +26,8 @@ export default function ApartSearchInput(props: TApartSearchInput) {
   const setWeakApartInfo = useWeakApartInfoStore(
     (state) => state.setWeakApartInfo
   );
+  const setIsReset = useSearchStore((state) => state.setIsReset);
+  const setSelectMarkerId = useMarkerStore((state) => state.setSelectMarkerId);
 
   useEffect(() => {
     if (map) {
@@ -43,9 +45,11 @@ export default function ApartSearchInput(props: TApartSearchInput) {
           addRecord(props.searchRef.current.value);
           setMainInfo("SEARCH");
           setIsSlide(true);
+          setIsReset(false);
           props.searchRef.current.blur();
           setApartInfo(null);
           setWeakApartInfo(null);
+          setSelectMarkerId(null);
         }
         props.setShowRecentSearch(false);
       }}

--- a/src/components/Common/ApartSearch/ApartSearchResultItem.tsx
+++ b/src/components/Common/ApartSearch/ApartSearchResultItem.tsx
@@ -31,7 +31,6 @@ export default function ApartSearchResultItem({
   const setSelectMarkerId = useMarkerStore((state) => state.setSelectMarkerId);
   const setIsLoading = useMarkerStore((state) => state.setIsLoading);
   const setIsReset = useSearchStore((state) => state.setIsReset);
-  const isReset = useSearchStore.getState().isReset;
   const { apartSeparate } = useLocationPath();
 
   const getApartData = async (url: string) => {
@@ -47,12 +46,12 @@ export default function ApartSearchResultItem({
   };
 
   const selectSearchApartHandler = (latitude: number, longitude: number) => {
+    setIsReset(true);
     if (map) {
       const newLocation = new naver.maps.LatLng(latitude, longitude);
       map.setCenter(newLocation);
       map.setZoom(18);
     }
-    if (isReset) setIsReset(false);
   };
 
   const selectSearchApartInfoHandler = async (
@@ -61,6 +60,7 @@ export default function ApartSearchResultItem({
     longitude: number
   ) => {
     if (map) {
+      setIsReset(true);
       try {
         const newLocation = new naver.maps.LatLng(latitude, longitude);
         map.setCenter(newLocation);
@@ -100,7 +100,6 @@ export default function ApartSearchResultItem({
     setMainInfo("SELECT");
     if (apartSeparate === "apt") setApartInfo(data.data);
     else setWeakApartInfo(data.data);
-    if (isReset) setIsReset(false);
   };
 
   return (

--- a/src/hooks/Search/useInfinityScroll.ts
+++ b/src/hooks/Search/useInfinityScroll.ts
@@ -40,7 +40,7 @@ export function useInfiniteScroll() {
 
   useEffect(() => {
     if (!keyword) return;
-    if (prevKeyword !== keyword || useSearchStore.getState().isReset) {
+    if (prevKeyword !== keyword || !useSearchStore.getState().isReset) {
       setItems([]);
       setPage(1);
       setHasMore(true);
@@ -52,7 +52,13 @@ export function useInfiniteScroll() {
   }, [keyword]);
 
   useEffect(() => {
-    if (inView && hasMore && !loading && keyword) {
+    if (
+      inView &&
+      hasMore &&
+      !loading &&
+      keyword &&
+      !useSearchStore.getState().isReset
+    ) {
       setPage((prevState) => prevState + 1);
       fetchData(page + 1, keyword);
     }

--- a/src/store/useSearchStore.ts
+++ b/src/store/useSearchStore.ts
@@ -12,7 +12,7 @@ type TUseSearchStore = {
 export const useSearchStore = create<TUseSearchStore>((set) => ({
   keyword: "",
   prevKeyword: "",
-  isReset: false,
+  isReset: true,
   setKeyword: (keyword: string) => set({ keyword }),
   setPrevKeyword: (prevKeyword: string) => set({ prevKeyword }),
   setIsReset: (isReset: boolean) => set({ isReset }),


### PR DESCRIPTION
## 📌 이슈 번호

> #73

## 💬 리뷰 포인트

> "위치보기", "정보보기" 지도 이동 이벤트 핸들러 이슈 수정

## 🚀 상세 설명

> "위치보기", "정보보기" 누를 시 지도 이동 이벤트 핸들러 이슈 수정하였습니다.

## 📸 스크린샷

## 📢 노트
> isReset상태변수 제거하고 items로만 로직 재구성할 예정입니다