### PR TITLE
[fix] 최근 검색어 클릭 이벤트 이슈 수정 #73

### DIFF
--- a/src/components/Common/ApartSearch/ApartRecentSearchList.tsx
+++ b/src/components/Common/ApartSearch/ApartRecentSearchList.tsx
@@ -18,6 +18,7 @@ export default function ApartRecentSearchList({
   const setIsSlide = useMainInfoStore.getState().setIsSlide;
   const setMainInfo = useMainInfoStore((state) => state.setMainInfo);
   const setKeyword = useSearchStore((state) => state.setKeyword);
+  const setIsReset = useSearchStore((state) => state.setIsReset);
 
   return (
     <div className={styles.recentSearch}>
@@ -44,6 +45,7 @@ export default function ApartRecentSearchList({
                     setKeyword(record.keyword);
                     setIsSlide(true);
                     setShowRecentSearch(false);
+                    setIsReset(false);
                     if (searchRef.current) {
                       searchRef.current.blur();
                     }


### PR DESCRIPTION
## 📌 이슈 번호

> #73

## 💬 리뷰 포인트

> 최근검색어 클릭 이벤트 이슈 수정

## 🚀 상세 설명

> "정보보기"누른 후 최근 검색어 클릭하면 결과리스트 안나오는 이슈 수정하였습니다.

## 📸 스크린샷

## 📢 노트
