### PR TITLE
[feat] ga 및 평균 매매가 포맷 함수 변경 #73

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,8 @@
         "typescript": "~5.6.2",
         "typescript-eslint": "^8.15.0",
         "vite": "^6.0.1",
-        "vite-plugin-html": "^3.2.2"
+        "vite-plugin-html": "^3.2.2",
+        "vite-plugin-radar": "^0.10.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5008,6 +5009,16 @@
       },
       "peerDependencies": {
         "vite": ">=2.0.0"
+      }
+    },
+    "node_modules/vite-plugin-radar": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-radar/-/vite-plugin-radar-0.10.0.tgz",
+      "integrity": "sha512-PRApileUv7I+bInGbrQM9LvxvrFHELRvyO5yAodGwIgQBRID/hOPqx0pz7VBWFAcPNjJJVAp/LuT1417BuE/9g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.15.0",
     "vite": "^6.0.1",
-    "vite-plugin-html": "^3.2.2"
+    "vite-plugin-html": "^3.2.2",
+    "vite-plugin-radar": "^0.10.0"
   }
 }

--- a/src/utils/parse/fotmatPriceCurrency.ts
+++ b/src/utils/parse/fotmatPriceCurrency.ts
@@ -1,7 +1,6 @@
 // 아파트 매매가 포맷 함수
-
 export const formatPriceCurrency = (num: number): string => {
-  const units = ["원", "만원", "억", "조"];
+  const units = ["만원", "억", "조"];
   let result = "";
   let unitIndex = 0;
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, loadEnv } from "vite";
 import { createHtmlPlugin } from "vite-plugin-html";
 import react from "@vitejs/plugin-react";
+import { VitePluginRadar } from "vite-plugin-radar";
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd());
@@ -13,6 +14,11 @@ export default defineConfig(({ mode }) => {
           data: {
             naverClientId: env.VITE_NAVER_MAP_CLIENT_ID,
           },
+        },
+      }),
+      VitePluginRadar({
+        analytics: {
+          id: env.VITE_PUBLIC_GOOGLE_ANALYTICS,
         },
       }),
     ],


### PR DESCRIPTION
## 📌 이슈 번호

> #73

## 💬 리뷰 포인트

> google analytics 및 평균 매매가 함수 변경

## 🚀 상세 설명

> google analytics 연결
> 평균 매매가 데이터에 따른 포맷 로직 변경

## 📸 스크린샷

## 📢 노트
